### PR TITLE
[#97]email認証時の成功メッセージの修正

### DIFF
--- a/app/controllers/users/user_auths_controller.rb
+++ b/app/controllers/users/user_auths_controller.rb
@@ -8,7 +8,7 @@ class Users::UserAuthsController < ApplicationController
   def show
     @user_auth = UserAuth.find_by!(provider: params[:provider], confirmation_token: params[:confirmation_token])
     @user_auth.confirm_by_token!
-    redirect_to new_user_session_path, notice: t('.confirmed')
+    redirect_to authenticated_root_path, notice: t('.confirmed')
   rescue UserAuth::ConfirmationExpired
     redirect_to root_path, alert: t('.confirmation_period_expired')
   end


### PR DESCRIPTION
### サマリー

登録直後のメール認証完了時に送信されたメール内のリンクから認証を実行するとログイン先ですでに「ログインしています」というメッセージが表示されていた
そこで認証後のリダイレクト先をauthenticated_root_pathに変更した。

close #97 

### 実装に所要した時間

0.2MH
