### PR TITLE
bundle update at 2019-01-26 06:01:51 JST

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bootstrap-ruby/bootstrap_form.git
-  revision: 3b53abba38b4c7c65ad8d0869153ee344cb37c19
+  revision: ea55335ac063e268d1acb871b37ab1b250d8e504
   branch: master
   specs:
-    bootstrap_form (4.0.0)
+    bootstrap_form (4.1.0)
       rails (>= 5.0)
 
 GEM
@@ -63,7 +63,7 @@ GEM
     arel (9.0.0)
     ast (2.4.0)
     aws-eventstream (1.0.1)
-    aws-partitions (1.133.0)
+    aws-partitions (1.135.0)
     aws-sdk-core (3.46.0)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
@@ -177,7 +177,7 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    graphiql-rails (1.5.0)
+    graphiql-rails (1.6.0)
       railties
       sprockets-rails
     graphql (1.8.13)
@@ -213,7 +213,7 @@ GEM
       domain_name (~> 0.5)
     http-form_data (2.1.1)
     http_parser.rb (0.6.0)
-    i18n (1.5.2)
+    i18n (1.5.3)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.2)
     jbuilder (2.8.0)
@@ -242,7 +242,7 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.7.0)
       launchy (~> 2.2)
-    license_finder (5.6.0)
+    license_finder (5.6.1)
       bundler
       rubyzip
       thor
@@ -350,9 +350,9 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    responders (2.4.0)
-      actionpack (>= 4.2.0, < 5.3)
-      railties (>= 4.2.0, < 5.3)
+    responders (2.4.1)
+      actionpack (>= 4.2.0, < 6.0)
+      railties (>= 4.2.0, < 6.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -374,7 +374,7 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.63.0)
+    rubocop (0.63.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
@@ -387,7 +387,7 @@ GEM
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
     rubyzip (1.2.2)
-    rufo (0.4.1)
+    rufo (0.4.2)
     safe_yaml (1.0.4)
     shellany (0.0.1)
     shoulda-matchers (3.1.2)


### PR DESCRIPTION
**Updated RubyGems:**

* [x] [aws-partitions](https://github.com/aws/aws-sdk-ruby): `1.133.0...1.135.0`
* [x] [bootstrap_form](https://github.com/bootstrap-ruby/bootstrap_form): [`3b53abba38b4c7c65ad8d0869153ee344cb37c19...ea55335ac063e268d1acb871b37ab1b250d8e504`](https://github.com/bootstrap-ruby/bootstrap_form/compare/3b53abba38b4c7c65ad8d0869153ee344cb37c19...ea55335ac063e268d1acb871b37ab1b250d8e504)
* [x] [graphiql-rails](https://github.com/rmosolgo/graphiql-rails): [`1.5.0...1.6.0`](https://github.com/rmosolgo/graphiql-rails/compare/v1.5.0...v1.6.0)
* [x] [i18n](https://github.com/ruby-i18n/i18n): [`1.5.2...1.5.3`](https://github.com/ruby-i18n/i18n/compare/v1.5.2...v1.5.3)
* [x] [license_finder](https://github.com/pivotal-legacy/LicenseFinder): [`5.6.0...5.6.1`](https://github.com/pivotal-legacy/LicenseFinder/compare/v5.6.0...v5.6.1)
* [x] [responders](https://github.com/plataformatec/responders): [`2.4.0...2.4.1`](https://github.com/plataformatec/responders/compare/v2.4.0...v2.4.1)
* [x] [rubocop](https://github.com/rubocop-hq/rubocop): [`0.63.0...0.63.1`](https://github.com/rubocop-hq/rubocop/compare/v0.63.0...v0.63.1)
* [x] [rufo](https://github.com/ruby-formatter/rufo): [`0.4.1...0.4.2`](https://github.com/ruby-formatter/rufo/compare/v0.4.1...v0.4.2)

Powered by [circleci-bundle-update-pr](https://rubygems.org/gems/circleci-bundle-update-pr)
